### PR TITLE
Terraform/GKE: switch from default node pool to a separately managed one

### DIFF
--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -9,26 +9,14 @@ resource "google_container_cluster" "gke-cluster" {
   name   = "xebikart-gke-${var.environment}-1"
   location = "europe-west1"
   project = "${google_project.xebikart.project_id}"
+
   min_master_version = "1.12.7-gke.7"
-  node_version = "1.12.7-gke.7"
+
+  remove_default_node_pool = true
   initial_node_count = 1
+
   monitoring_service = "monitoring.googleapis.com/kubernetes"
   logging_service = "logging.googleapis.com/kubernetes"
-
-
-  node_config {
-    oauth_scopes = [
-      # Defaults
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-      # For External-DNS
-      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
-    ]
-  }
 
   addons_config {
     kubernetes_dashboard {
@@ -41,3 +29,44 @@ resource "google_container_cluster" "gke-cluster" {
     "google_project_services.project_services"
   ]
 }
+
+resource "google_container_node_pool" "main-nodes" {
+  name       = "main-node-pool"
+  location   = "europe-west1"
+  project = "${google_project.xebikart.project_id}"
+
+  cluster    = "${google_container_cluster.gke-cluster.name}"
+  initial_node_count = 1
+
+  management {
+    auto_repair = true
+    auto_upgrade = true
+  }
+
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 5
+  }
+
+  node_config {
+    #preemptible  = true
+    machine_type = "n1-standard-1"
+
+    #metadata = {
+    #  disable-legacy-endpoints = "true"
+    #}
+
+    oauth_scopes = [
+      # Defaults
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+      # For External-DNS
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+    ]
+  }
+}
+


### PR DESCRIPTION
The GKE cluster now uses a separately node pool:

- It will make it more natural to add GPU node pools later on
- This pool now has auto-upgrade and auto-repair enabled

This node pool also has **autoscaling enabled** on it, from 1 to 5 nodes per region for now :tada: 