### PR TITLE
Activate Prometheus exporter

### DIFF
--- a/kubernetes/rabbitmq/values.yaml
+++ b/kubernetes/rabbitmq/values.yaml
@@ -1,18 +1,14 @@
-# Config for rabbitmq-ha (alias)
-global:
-  rabbitmqMqttPort: 1883
 rabbitmq-ha:
   replicaCount: 2
+  extraLabels:
+    type: infra
+    layer: backend
   service:
     type: LoadBalancer
     # Explicietly override clusterIP so its default value doesn't conflict with LoadBalancer
     clusterIP: null
     annotations:
       external-dns.alpha.kubernetes.io/hostname: rabbitmq.xebik.art
-  metadata:
-    name: my-message-broker
-  labels:
-    app: message-broker
   rabbitmqMQTTPlugin:
     enabled: true
     # TODO: handler storage: https://www.rabbitmq.com/mqtt.html
@@ -43,3 +39,9 @@ rabbitmq-ha:
     queues: |-
       {"name":"kart-events", "vhost":"/", "durable":true, "auto_delete":false, "arguments":{}},
       {"name":"race-events", "vhost":"/", "durable":true, "auto_delete":false, "arguments":{}}
+  prometheus:
+    exporter:
+      enabled: true
+    alerts:
+      enabled: false
+


### PR DESCRIPTION
Activate Prometheus exporter for RabbitMQ

This pull request active a sidecar container in RabbitMQ pods that exposes metrics in Prometheus format

This PR is related to this issue: https://github.com/xebia-france/xebikart-infra/issues/35