### PR TITLE
Terraform: add GCP Service Accounts for CircleCI and ManagedCertificates

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -3,7 +3,7 @@ export TERRAFORM_CMD = docker run -it --rm \
 			-v `pwd`:/root/terraform \
 			-v gcloud-xebikart-config:/root/.config \
 			-w /root/terraform \
-			hashicorp/terraform:0.11.7
+			hashicorp/terraform:0.11.13
 
 # This Makefile wrapp all terraform commands via docker#
 # To run this commands you must be logged in with the `gcloud` CLI. See README

--- a/terraform/service-accounts.tf
+++ b/terraform/service-accounts.tf
@@ -1,0 +1,47 @@
+# CircleCI
+
+resource "google_service_account" "circleci" {
+  project      = "${google_project.xebikart.project_id}"
+  account_id   = "xebikart-circleci"
+  display_name = "XebiKart - CircleCI user"
+}
+
+resource "google_project_iam_member" "circleci-iam-gcr" {
+  project = "${google_project.xebikart.project_id}"
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.circleci.email}"
+}
+
+resource "google_project_iam_member" "circleci-iam-gke" {
+  project = "${google_project.xebikart.project_id}"
+  role    = "roles/container.admin"
+  member  = "serviceAccount:${google_service_account.circleci.email}"
+}
+
+# Managed certificates
+# https://github.com/GoogleCloudPlatform/gke-managed-certs/issues/14
+
+resource "google_service_account" "managedcerts-controller-gke" {
+  project      = "${google_project.xebikart.project_id}"
+  account_id   = "xebikart-managedcerts-gke"
+  display_name = "XebiKart - User for Managed Certificates controller on GKE"
+}
+
+resource "google_project_iam_custom_role" "certificates-management-role" {
+  project      = "${google_project.xebikart.project_id}"
+  role_id     = "certificatesAdmin"
+  title       = "Certificates Management admin role"
+  description = "Certificates Management admin role"
+  permissions = [
+    "compute.sslCertificates.create",
+    "compute.sslCertificates.delete",
+    "compute.sslCertificates.get",
+    "compute.sslCertificates.list",
+  ]
+}
+
+resource "google_project_iam_member" "managedcerts-iam-gke" {
+  project = "${google_project.xebikart.project_id}"
+  role    = "projects/${google_project.xebikart.project_id}/roles/${google_project_iam_custom_role.certificates-management-role.role_id}"
+  member  = "serviceAccount:${google_service_account.managedcerts-controller-gke.email}"
+}


### PR DESCRIPTION
This has already been applied and SA are being used for a while. Just pushing it now. ManagedCertifiactes SA will probably disappear soon