### PR TITLE
Disable PrometheusOperator creation

### DIFF
--- a/kubernetes/rabbitmq/values.yaml
+++ b/kubernetes/rabbitmq/values.yaml
@@ -44,6 +44,8 @@ rabbitmq-ha:
   prometheus:
     exporter:
       enabled: true
+    operator:
+      enabled: false
     alerts:
       enabled: false
 


### PR DESCRIPTION
In order to scrap Prometheus metrics, we need to create a [Prometheus Operator](https://github.com/coreos/prometheus-operator). `rabitmq-ha` Chart creates one of this by default when Prometheus exporter is enabled.

- This operator uses a CRD called ServiceMonitor that MUST be deployed in our cluster before deploying
- This Chart creates a full instance of Prometheus and other related resources in the same `namespace` where RabbitMQ is deployed which is not great for resource isolation

We'll use another Chart called[ `prometheus-operator`](https://github.com/helm/charts/tree/master/stable/prometheus-operator) that handles this properly.
 