### PR TITLE
Delete amqp queues configuration

### DIFF
--- a/kubernetes/rabbitmq/values.yaml
+++ b/kubernetes/rabbitmq/values.yaml
@@ -5,7 +5,7 @@ rabbitmq-ha:
     layer: backend
   service:
     type: LoadBalancer
-    # Explicietly override clusterIP so its default value doesn't conflict with LoadBalancer
+    # Explicitly override clusterIP so its default value doesn't conflict with LoadBalancer
     clusterIP: ""
     annotations:
       external-dns.alpha.kubernetes.io/hostname: rabbitmq.xebik.art


### PR DESCRIPTION
As we don't use AMQP queues for now, I've deleted that configuration