### PR TITLE
Spring cleaning and customize Prometheus exporter

### DIFF
--- a/kubernetes/rabbitmq/values.yaml
+++ b/kubernetes/rabbitmq/values.yaml
@@ -35,6 +35,8 @@ rabbitmq-ha:
   prometheus:
     exporter:
       enabled: true
+      env:
+        RABBIT_EXPORTERS: "exchange,node,queue,connections"
     operator:
       enabled: false
     alerts:


### PR DESCRIPTION
- Delete custom RabbitMQ exchange. By default, RabbitMQ creates one and we don't need to change the default behavior by now
- Tweak Prometheus exporter to add user information in metrics. Using this, we can group all metrics by user, which is great to create stunning Grafana Dashboards :)